### PR TITLE
Member패키지 테스트코드 작성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/daily/daily/common/dto/ExceptionResponseDTO.java
+++ b/backend/src/main/java/com/daily/daily/common/dto/ExceptionResponseDTO.java
@@ -1,6 +1,7 @@
 package com.daily.daily.common.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/backend/src/main/java/com/daily/daily/member/constant/MemberRole.java
+++ b/backend/src/main/java/com/daily/daily/member/constant/MemberRole.java
@@ -6,7 +6,5 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberRole {
-    MEMBER("ROLE_MEMBER"), ADMIN("ROLE_ADMIN");
-
-    private final String key;
+    ROLE_MEMBER, ROLE_ADMIN
 }

--- a/backend/src/main/java/com/daily/daily/member/controller/MemberController.java
+++ b/backend/src/main/java/com/daily/daily/member/controller/MemberController.java
@@ -88,6 +88,5 @@ public class MemberController {
     public CommonResponseDTO updatePassword(@RequestBody @Valid PasswordUpdateDTO passwordUpdateDTO, @AuthenticationPrincipal Member member) {
         memberService.updatePassword(passwordUpdateDTO, member);
         return new CommonResponseDTO(true, HttpStatus.OK.value());
-
     }
 }

--- a/backend/src/main/java/com/daily/daily/member/controller/MemberController.java
+++ b/backend/src/main/java/com/daily/daily/member/controller/MemberController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,7 +44,7 @@ public class MemberController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/check-username")
-    public DuplicateResultDTO checkDuplicatedUsername(String username) {
+    public DuplicateResultDTO checkDuplicatedUsername(@RequestParam("username") String username) {
         System.out.println(username);
         if (memberService.existsByUsername(username)) {
             return new DuplicateResultDTO(true);
@@ -54,7 +55,7 @@ public class MemberController {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/check-nickname")
-    public DuplicateResultDTO checkDuplicatedNickname(String nickname) {
+    public DuplicateResultDTO checkDuplicatedNickname(@RequestParam("nickname") String nickname) {
         if (memberService.existsByNickname(nickname)) {
             return new DuplicateResultDTO(true);
         }

--- a/backend/src/main/java/com/daily/daily/member/domain/Member.java
+++ b/backend/src/main/java/com/daily/daily/member/domain/Member.java
@@ -31,7 +31,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
     private String nickname;
     private String email;
     @Enumerated(EnumType.STRING)
-    private MemberRole role = MemberRole.MEMBER;
+    private MemberRole role = MemberRole.ROLE_MEMBER;
     private String socialId;
     @Enumerated(EnumType.STRING)
     private SocialType socialType;

--- a/backend/src/main/java/com/daily/daily/member/domain/Member.java
+++ b/backend/src/main/java/com/daily/daily/member/domain/Member.java
@@ -31,7 +31,7 @@ public class Member extends BaseTimeEntity implements UserDetails {
     private String nickname;
     private String email;
     @Enumerated(EnumType.STRING)
-    private MemberRole role = MemberRole.ROLE_MEMBER;
+    private MemberRole role;
     private String socialId;
     @Enumerated(EnumType.STRING)
     private SocialType socialType;

--- a/backend/src/main/java/com/daily/daily/member/dto/JoinDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/JoinDTO.java
@@ -3,11 +3,13 @@ package com.daily.daily.member.dto;
 
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.validator.Nickname;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
@@ -15,6 +17,7 @@ import java.util.regex.Matcher;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class JoinDTO {
     @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "특수문자를 제외한 문자만 입력하세요.")

--- a/backend/src/main/java/com/daily/daily/member/dto/JoinDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/JoinDTO.java
@@ -4,7 +4,9 @@ package com.daily.daily.member.dto;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.validator.Nickname;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
@@ -13,6 +15,7 @@ import java.util.regex.Matcher;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class JoinDTO {
     @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "특수문자를 제외한 문자만 입력하세요.")
     @Length(min = 4, max = 15)

--- a/backend/src/main/java/com/daily/daily/member/dto/JoinDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/JoinDTO.java
@@ -1,6 +1,7 @@
 package com.daily.daily.member.dto;
 
 
+import com.daily.daily.member.constant.MemberRole;
 import com.daily.daily.member.domain.Member;
 import com.daily.daily.member.validator.Nickname;
 import jakarta.annotation.Nullable;
@@ -37,6 +38,7 @@ public class JoinDTO {
                 .username(username)
                 .password(password)
                 .nickname(nickname)
+                .role(MemberRole.ROLE_MEMBER)
                 .build();
     }
 }

--- a/backend/src/main/java/com/daily/daily/member/dto/MemberInfoDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/MemberInfoDTO.java
@@ -2,12 +2,17 @@ package com.daily.daily.member.dto;
 
 import com.daily.daily.member.domain.Member;
 import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
 public class MemberInfoDTO {
     private Long id;
     private String username;

--- a/backend/src/main/java/com/daily/daily/member/dto/NicknameDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/NicknameDTO.java
@@ -4,12 +4,16 @@ import com.daily.daily.member.validator.Nickname;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class NicknameDTO {
     //한글로하면 10자 영어숫자로하면 15자가 되도록
     @NotBlank

--- a/backend/src/main/java/com/daily/daily/member/dto/PasswordUpdateDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/PasswordUpdateDTO.java
@@ -3,12 +3,14 @@ package com.daily.daily.member.dto;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 public class PasswordUpdateDTO {
     @NotBlank
     private String presentPassword;

--- a/backend/src/main/java/com/daily/daily/member/dto/PasswordUpdateDTO.java
+++ b/backend/src/main/java/com/daily/daily/member/dto/PasswordUpdateDTO.java
@@ -1,12 +1,14 @@
 package com.daily.daily.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class PasswordUpdateDTO {
     @NotBlank
     private String presentPassword;

--- a/backend/src/main/java/com/daily/daily/member/validator/NicknameValidator.java
+++ b/backend/src/main/java/com/daily/daily/member/validator/NicknameValidator.java
@@ -15,6 +15,7 @@ public class NicknameValidator implements ConstraintValidator<Nickname, String> 
 
     @Override
     public boolean isValid(String nickname, ConstraintValidatorContext context) {
+        if (nickname == null) return true;
         if (!pattern.matcher(nickname).matches()) {
             return false;
         }

--- a/backend/src/main/java/com/daily/daily/oauth/OAuthAttributes.java
+++ b/backend/src/main/java/com/daily/daily/oauth/OAuthAttributes.java
@@ -54,7 +54,7 @@ public class OAuthAttributes {
                 .socialId(oauth2UserInfo.getId())
                 .username(oauth2UserInfo.getEmail())
                 .email(oauth2UserInfo.getEmail())
-                .role(MemberRole.MEMBER)
+                .role(MemberRole.ROLE_MEMBER)
                 .build();
     }
 }

--- a/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
@@ -32,7 +32,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         try {
             OAuth2CustomUser oAuth2User = (OAuth2CustomUser) authentication.getPrincipal();
 
-            if(oAuth2User.getMemberRole() == MemberRole.MEMBER) {
+            if(oAuth2User.getMemberRole() == MemberRole.ROLE_MEMBER) {
                 String accessToken = jwtUtil.generateToken(oAuth2User.getUsername());
                 response.addHeader(jwtUtil.getAccessHeader(), accessToken);
                 response.sendRedirect("/"); // 프론트의 회원가입 추가 정보 입력 폼으로 리다이렉트

--- a/backend/src/main/java/com/daily/daily/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/daily/daily/oauth/service/CustomOAuth2UserService.java
@@ -45,7 +45,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         Member createdMember = getMember(extractAttributes, socialType);
 
         return new OAuth2CustomUser(
-                Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().getKey())),
+                Collections.singleton(new SimpleGrantedAuthority(createdMember.getRole().name())),
                 attributes,
                 extractAttributes.getNameAttributeKey(),
                 createdMember.getEmail(),

--- a/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
@@ -1,11 +1,229 @@
 package com.daily.daily.member.controller;
 
+import com.daily.daily.common.dto.ExceptionResponseDTO;
 import com.daily.daily.member.dto.JoinDTO;
+import com.daily.daily.member.dto.MemberInfoDTO;
+import com.daily.daily.member.dto.NicknameDTO;
+import com.daily.daily.member.dto.PasswordUpdateDTO;
+import com.daily.daily.member.exception.DuplicatedUsernameException;
+import com.daily.daily.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.nio.charset.StandardCharsets;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@MockBean(JpaMetamodelMappingContext.class)
 class MemberControllerTest {
+    @Autowired
+    MockMvc mockMvc;
 
+    @MockBean
+    MemberService memberService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser
+    @DisplayName("회원가입이 성공한 경우의 응답을 검사한다.")
+    void joinSuccessCase() throws Exception {
+        //given
+        JoinDTO joinDTO = new JoinDTO("geonwoo123", "pass1234", null);
+        MemberInfoDTO expected = new MemberInfoDTO(1L, "geonwoo123", "난폭한사자");
+
+        given(memberService.join(Mockito.any())).willReturn(expected);
+        //when
+        ResultActions joinActions = mockMvc.perform(post("/api/member/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(joinDTO))
+                .with(csrf())
+        );
+        //then
+        String content = joinActions.andExpect(status().isCreated())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        MemberInfoDTO actual = objectMapper.readValue(content, MemberInfoDTO.class);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("중복된 username으로 회원가입이 실패하였을 경우 응답을 검사한다.")
+    void joinFailureCase() throws Exception {
+        //given
+        JoinDTO joinDTO = new JoinDTO("geonwoo123", "pass1234", null);
+
+        given(memberService.join(Mockito.any())).willThrow(DuplicatedUsernameException.class);
+
+        //when
+        ResultActions joinActions = mockMvc.perform(post("/api/member/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(joinDTO))
+                .with(csrf())
+
+        );
+
+        //then
+        joinActions.andExpect(status().isConflict())
+                .andExpect(jsonPath("$.statusCode").value(409));
+    }
+
+    /**
+     * 얘는 Authnetication Principal 리팩토링 하고 작성하는게 좋을듯
+     */
+    @Test
+    @WithMockUser
+    void getMemberByAccessToken() {
+        String token = "testJwtToken";
+        MemberInfoDTO expected = new MemberInfoDTO(1L, "geonwoo123", "미친고양이");
+
+        
+    }
+    @WithMockUser
+    @Test
+    @DisplayName("중복된 username이 있을경우 응답을 검사한다.")
+    void checkDuplicatedUsernameCase() throws Exception {
+        //given
+        String testUsername = "username123";
+        given(memberService.existsByUsername(testUsername)).willReturn(true);
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/api/member/check-username")
+                .param("username", testUsername)
+        );
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicated").value(true));
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("중복된 username이 없는경우 응답을 검사한다.")
+    void checkNoneDuplicatedUsernameCase() throws Exception {
+        //given
+        String testUsername = "username123";
+        given(memberService.existsByUsername(testUsername)).willReturn(false);
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/api/member/check-username")
+                .param("username", testUsername)
+        );
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicated").value(false));
+
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("중복된 nickname이 있는경우 반환값을 검사한다.")
+    void checkDuplicatedNicknameCase() throws Exception{
+        //given
+        String testNickname = "nickname";
+        given(memberService.existsByNickname(testNickname)).willReturn(true);
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/api/member/check-nickname")
+                .param("nickname", testNickname)
+        );
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicated").value(true));
+    }
+
+    @WithMockUser
+    @Test
+    @DisplayName("중복된 nickname이 없는경우 반환값을 검사한다.")
+    void checkNoneDuplicatedNicknameCase() throws Exception{
+        //given
+        String testNickname = "nickname";
+        given(memberService.existsByNickname(testNickname)).willReturn(false);
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/api/member/check-nickname")
+                .param("nickname", testNickname)
+        );
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicated").value(false));
+    }
+
+    @Test
+    void checkDuplicatedEmail() {
+    }
+
+    @WithMockUser
+    @Test
+    void updateNickname() throws Exception {
+        //given
+        NicknameDTO nicknameDTO = new NicknameDTO("mynickname");
+        MemberInfoDTO expected = new MemberInfoDTO(1L, "geonwoo123", "난폭한사자");
+
+        given(memberService.updateNickname(Mockito.any(), Mockito.any())).willReturn(expected);
+        //when
+        ResultActions perform = mockMvc.perform(patch("/api/member/nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(nicknameDTO))
+                .with(csrf())
+        );
+        //then
+        String content = perform.andExpect(status().isOk())
+                .andDo(print())
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        MemberInfoDTO actual = objectMapper.readValue(content, MemberInfoDTO.class);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @WithMockUser
+    @Test
+    void updatePassword() throws Exception{
+        //given
+        PasswordUpdateDTO passwordUpdateDTO = new PasswordUpdateDTO("12345678","23456789");
+
+        //when
+        ResultActions perform = mockMvc.perform(patch("/api/member/password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(passwordUpdateDTO))
+                .with(csrf())
+        );
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.successful").value(true))
+                .andExpect(jsonPath("$.statusCode").value(200));
+    }
 }

--- a/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.daily.daily.member.repository;
+
+import com.daily.daily.member.constant.MemberRole;
+import com.daily.daily.member.domain.Member;
+import com.daily.daily.member.validator.Nickname;
+import com.daily.daily.oauth.constant.SocialType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    static final String TEST_USERNAME = "geonwoo123";
+    static final String TEST_NICKNAME = "다일리123";
+    static final String TEST_EMAIL = "geonwoo123@naver.com";
+
+    @Autowired MemberRepository memberRepository;
+    
+    @BeforeEach()
+    void saveTestData() {
+        Member testMember = Member.builder()
+                .username(TEST_USERNAME)
+                .nickname(TEST_NICKNAME)
+                .email(TEST_EMAIL)
+                .role(MemberRole.MEMBER)
+                .build();
+
+        memberRepository.save(testMember);
+    }
+    @Test
+    void findByUsername() {
+        Member findMember = memberRepository.findByUsername(TEST_USERNAME)
+                .orElseThrow(NoSuchElementException::new);
+
+        assertFromFindMember(findMember);
+    }
+
+    private static void assertFromFindMember(Member findMember) {
+        assertThat(findMember.getUsername()).isEqualTo(TEST_USERNAME);
+        assertThat(findMember.getNickname()).isEqualTo(TEST_NICKNAME);
+        assertThat(findMember.getRole()).isEqualTo(MemberRole.MEMBER);
+    }
+
+    @Test
+    void existsByUsername() {
+        boolean isExist = memberRepository.existsByUsername(TEST_USERNAME);
+        boolean isNotExist = memberRepository.existsByUsername("존재하지 않는 username");
+
+        assertThat(isExist).isTrue();
+        assertThat(isNotExist).isFalse();
+    }
+
+    @Test
+    void existsByNickname() {
+        boolean isExist = memberRepository.existsByNickname(TEST_NICKNAME);
+        boolean isNotExist = memberRepository.existsByNickname("존재하지 않는 nickname");
+
+        assertThat(isExist).isTrue();
+        assertThat(isNotExist).isFalse();
+    }
+
+    @Test
+    void existsByEmail() {
+        boolean isExist = memberRepository.existsByEmail(TEST_EMAIL);
+        boolean isNotExist = memberRepository.existsByEmail("존재하지 않는 email");
+        assertThat(isExist).isTrue();
+        assertThat(isNotExist).isFalse();
+    }
+
+    @Test
+    void findBySocialTypeAndSocialId() {
+        //given
+        String testEmail = "geonwoo123@gmail.com";
+        Member member = Member.builder()
+                .socialType(SocialType.GOOGLE)
+                .socialId("socialId")
+                .email(testEmail)
+                .build();
+
+        memberRepository.save(member);
+
+        //when
+        Member findMember = memberRepository.findBySocialTypeAndSocialId(SocialType.GOOGLE, "socialId")
+                .orElseThrow(NoSuchElementException::new);
+
+        //then
+        assertThat(findMember.getEmail()).isEqualTo(testEmail);
+    }
+}

--- a/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
@@ -34,7 +34,7 @@ class MemberRepositoryTest {
                 .username(TEST_USERNAME)
                 .nickname(TEST_NICKNAME)
                 .email(TEST_EMAIL)
-                .role(MemberRole.MEMBER)
+                .role(MemberRole.ROLE_MEMBER)
                 .build();
 
         memberRepository.save(testMember);
@@ -46,7 +46,8 @@ class MemberRepositoryTest {
 
         assertThat(findMember.getUsername()).isEqualTo(TEST_USERNAME);
         assertThat(findMember.getNickname()).isEqualTo(TEST_NICKNAME);
-        assertThat(findMember.getRole()).isEqualTo(MemberRole.MEMBER);    }
+        assertThat(findMember.getRole()).isEqualTo(MemberRole.ROLE_MEMBER);
+    }
 
     @Test
     void existsByUsername() {
@@ -70,7 +71,7 @@ class MemberRepositoryTest {
     void existsByEmail() {
         boolean isExist = memberRepository.existsByEmail(TEST_EMAIL);
         boolean isNotExist = memberRepository.existsByEmail("존재하지 않는 email");
-        
+
         assertThat(isExist).isTrue();
         assertThat(isNotExist).isFalse();
     }

--- a/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/daily/daily/member/repository/MemberRepositoryTest.java
@@ -44,14 +44,9 @@ class MemberRepositoryTest {
         Member findMember = memberRepository.findByUsername(TEST_USERNAME)
                 .orElseThrow(NoSuchElementException::new);
 
-        assertFromFindMember(findMember);
-    }
-
-    private static void assertFromFindMember(Member findMember) {
         assertThat(findMember.getUsername()).isEqualTo(TEST_USERNAME);
         assertThat(findMember.getNickname()).isEqualTo(TEST_NICKNAME);
-        assertThat(findMember.getRole()).isEqualTo(MemberRole.MEMBER);
-    }
+        assertThat(findMember.getRole()).isEqualTo(MemberRole.MEMBER);    }
 
     @Test
     void existsByUsername() {
@@ -75,6 +70,7 @@ class MemberRepositoryTest {
     void existsByEmail() {
         boolean isExist = memberRepository.existsByEmail(TEST_EMAIL);
         boolean isNotExist = memberRepository.existsByEmail("존재하지 않는 email");
+        
         assertThat(isExist).isTrue();
         assertThat(isNotExist).isFalse();
     }

--- a/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -32,6 +33,8 @@ import static org.mockito.Mockito.when;
 class MemberServiceTest {
     @Mock
     MemberRepository memberRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
     @InjectMocks
     MemberService memberService;
 

--- a/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
@@ -97,24 +97,41 @@ class MemberServiceTest {
     @Test
     @DisplayName("비밀번호를 변경할 때, 현재 입력된 비밀번호가 올바르지 않으면 PasswordUnmatchedException이 발생한다.")
     void updatePassword1() {
-         //given
-        Member member = Member.builder()
-                .id(1L)
-                .username("username1")
-                .nickname("nickname")
-                .password(new BCryptPasswordEncoder().encode("myPassword123"))
-                .build();
+        //given
+        Member testMember = createTestMember("myPassword123");
 
         PasswordUpdateDTO wrongPasswordDTO = new PasswordUpdateDTO("wrongPassword", "updatePassword");
-        PasswordUpdateDTO correctPasswordDTO = new PasswordUpdateDTO("myPassword123", "updatePassword");
-        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
 
         MemberService testMemberService = new MemberService(new BCryptPasswordEncoder(), memberRepository); // 실제 BCrypt인코더 주입, memberRepository는 Mock객체
 
         //when, then
-        assertThatThrownBy(() -> testMemberService.updatePassword(wrongPasswordDTO, member))
+        assertThatThrownBy(() -> testMemberService.updatePassword(wrongPasswordDTO, testMember))
                 .isInstanceOf(PasswordUnmatchedException.class); // wrong case
 
-        testMemberService.updatePassword(correctPasswordDTO, member); // correct case. no exception
+    }
+
+    @Test
+    @DisplayName("비밀번호를 변경할 때, 현재 입력된 비밀번호가 올바르면 예외가 발생하지 않는다.")
+    void updatePassword2() {
+        //given
+        Member testMember = createTestMember("myPassword123");
+
+        PasswordUpdateDTO correctPasswordDTO = new PasswordUpdateDTO("myPassword123", "updatePassword");
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+
+        MemberService testMemberService = new MemberService(new BCryptPasswordEncoder(), memberRepository); // 실제 BCrypt인코더 주입, memberRepository는 Mock객체
+
+        //when, then
+        testMemberService.updatePassword(correctPasswordDTO, testMember); // correct case. no exception
+    }
+
+    private Member createTestMember(String password) {
+        return Member.builder()
+                .id(1L)
+                .username("username1")
+                .nickname("nickname")
+                .password(new BCryptPasswordEncoder().encode(password))
+                .build();
     }
 }

--- a/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/daily/daily/member/service/MemberServiceTest.java
@@ -1,0 +1,117 @@
+package com.daily.daily.member.service;
+
+import com.daily.daily.member.domain.Member;
+import com.daily.daily.member.dto.JoinDTO;
+import com.daily.daily.member.dto.MemberInfoDTO;
+import com.daily.daily.member.dto.PasswordUpdateDTO;
+import com.daily.daily.member.exception.DuplicatedNicknameException;
+import com.daily.daily.member.exception.DuplicatedUsernameException;
+import com.daily.daily.member.exception.PasswordUnmatchedException;
+import com.daily.daily.member.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @Mock
+    MemberRepository memberRepository;
+    @InjectMocks
+    MemberService memberService;
+
+    @Test
+    @DisplayName("joinDTO의 정보에 맞게 회원가입이 된 멤버의 정보를 반환해야 한다")
+    void join1() {
+        //given
+        JoinDTO joinDTO = new JoinDTO("username1", "password123", "다일리4141221");
+
+        //when
+        MemberInfoDTO memberInfoDTO = memberService.join(joinDTO);
+
+        //then
+        assertThat(joinDTO.getUsername()).isEqualTo(memberInfoDTO.getUsername());
+        assertThat(joinDTO.getNickname()).isEqualTo(memberInfoDTO.getNickname());
+    }
+
+
+    @Test
+    @DisplayName("username이 중복되었을 때에는 DuplicatedUsernameException이 발생해야 한다.")
+    void join2() {
+        //given
+        JoinDTO joinDTO = new JoinDTO("username1", "password123", "다일리441231");
+        when(memberRepository.existsByUsername("username1")).thenReturn(true);
+
+        //when, then
+        assertThatThrownBy(() -> memberService.join(joinDTO)).isInstanceOf(DuplicatedUsernameException.class);
+    }
+
+    @Test
+    @DisplayName("nickname이 중복되었을 때에는 DuplicatedNicknameException이 발생해야 한다.")
+    void join3() {
+        //given
+        JoinDTO joinDTO = new JoinDTO("username1", "password123", "다일리441231");
+        when(memberRepository.existsByNickname("다일리441231")).thenReturn(true);
+
+        //when, then
+        assertThatThrownBy(() -> memberService.join(joinDTO))
+                .isInstanceOf(DuplicatedNicknameException.class);
+    }
+
+    @Test
+    @DisplayName("닉네임을 변경할 때, 변경하고 싶은 닉네임이 이미 존재하면 DuplicatedNicknameException이 발생한다.")
+    void updateNickname() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .username("username1")
+                .nickname("임시닉네임")
+                .build();
+
+        when(memberRepository.existsByNickname("바꾸고 싶은 닉네임")).thenReturn(true);
+        when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+
+        //when, then
+        assertThatThrownBy(() -> memberService.updateNickname(member, "바꾸고 싶은 닉네임"))
+                .isInstanceOf(DuplicatedNicknameException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호를 변경할 때, 현재 입력된 비밀번호가 올바르지 않으면 PasswordUnmatchedException이 발생한다.")
+    void updatePassword1() {
+         //given
+        Member member = Member.builder()
+                .id(1L)
+                .username("username1")
+                .nickname("nickname")
+                .password(new BCryptPasswordEncoder().encode("myPassword123"))
+                .build();
+
+        PasswordUpdateDTO wrongPasswordDTO = new PasswordUpdateDTO("wrongPassword", "updatePassword");
+        PasswordUpdateDTO correctPasswordDTO = new PasswordUpdateDTO("myPassword123", "updatePassword");
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+        MemberService testMemberService = new MemberService(new BCryptPasswordEncoder(), memberRepository); // 실제 BCrypt인코더 주입, memberRepository는 Mock객체
+
+        //when, then
+        assertThatThrownBy(() -> testMemberService.updatePassword(wrongPasswordDTO, member))
+                .isInstanceOf(PasswordUnmatchedException.class); // wrong case
+
+        testMemberService.updatePassword(correctPasswordDTO, member); // correct case. no exception
+    }
+}

--- a/backend/src/test/java/com/daily/daily/member/validator/NicknameValidatorTest.java
+++ b/backend/src/test/java/com/daily/daily/member/validator/NicknameValidatorTest.java
@@ -1,15 +1,60 @@
 package com.daily.daily.member.validator;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class NicknameValidatorTest {
 
+    NicknameValidator nicknameValidator = new NicknameValidator();
     @Test
-    @DisplayName("한글, 숫자, 영어이외의 문자열로 닉네임으로 만들수 없다.")
+    @DisplayName("한글, 숫자, 영어이외의 문자를 사용하여 닉네임으로 만들수 없다.")
     void isValid1() {
+        boolean isInvalid1 = nicknameValidator.isValid("안 녕", null);
+        boolean isInvalid2 = nicknameValidator.isValid("!!", null);
 
+        assertThat(isInvalid1).isFalse();
+        assertThat(isInvalid2).isFalse();
     }
+    @Test
+    @DisplayName("한글은 한 글자에 사이즈3, 영어와 숫자는 한 글자에 사이즈2로 책정할 때, 닉네임의 총 사이즈가 30을 초과하면 유효하지 않다")
+    void isValid2() {
+        boolean isInvalid1 = nicknameValidator.isValid("열한글자인닉네임이에요", null);
+        boolean isInvalid2 = nicknameValidator.isValid("aaaaabbbbb333334", null);// 16글자 -> 2 * 16 = 32
+        boolean isInvalid3 = nicknameValidator.isValid("한글여섯글자abcd123", null);// 3*6 + 2*7 = 32 -> 예외발생.
+
+        assertThat(isInvalid1).isFalse();
+        assertThat(isInvalid2).isFalse();
+        assertThat(isInvalid3).isFalse();
+    }
+
+    @Test
+    @DisplayName("한글 영어 숫자 상관없이 닉네임의 길이는 2를 넘어야한다.")
+    void isValid3() {
+        boolean isInvalid1 = nicknameValidator.isValid("아", null);
+        boolean isInvalid2 = nicknameValidator.isValid("3", null);
+
+        assertThat(isInvalid1).isFalse();
+        assertThat(isInvalid2).isFalse();
+    }
+
+    @Test
+    @DisplayName("위의 예외케이스가 아닌 성공적인 닉네임 케이스들을 테스트한다.")
+    void isValid5() {
+        boolean isValid = nicknameValidator.isValid("박건우123", null);
+        boolean isValid2 = nicknameValidator.isValid("geonwoo123", null);
+        boolean isValid3 = nicknameValidator.isValid("한글열글자닉네임", null);
+        boolean isValid4 = nicknameValidator.isValid("aaaaabbbbb55555", null); // 영어,숫자 15글자 => Size : 30 (2 * 15)
+
+        assertThat(isValid).isTrue();
+        assertThat(isValid2).isTrue();
+        assertThat(isValid3).isTrue();
+        assertThat(isValid4).isTrue();
+    }
+
+
+
 }

--- a/backend/src/test/java/com/daily/daily/member/validator/NicknameValidatorTest.java
+++ b/backend/src/test/java/com/daily/daily/member/validator/NicknameValidatorTest.java
@@ -1,0 +1,15 @@
+package com.daily.daily.member.validator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NicknameValidatorTest {
+
+    @Test
+    @DisplayName("한글, 숫자, 영어이외의 문자열로 닉네임으로 만들수 없다.")
+    void isValid1() {
+
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close: #67 
## 작업 내용
## 의논할 거리
- MemberRole을 다음과 같이 정리 (Security 기본 권한문제)
```java
public enum MemberRole {
    ROLE_MEMBER, ROLE_ADMIN
}
```
- Member 도메인 안에서 MemberRole 값을 필드에서 셋팅하는것을 삭제했습니다. (깃허브 액션에서 자꾸 에러로그로떠서)
- 컨트롤러 계층의 테스트를 꼬박꼬박 다 작성하는 것이 맞는지 모르겠네요
   - 생산성이 너무 떨어진다는 느낌을 받았습니다. 

## Merge 전에 해야할 작업
## 기타
ㅎㅇㅌ.......!!!!