### PR TITLE
Spring Restdocs를 이용한 API 문서화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -63,16 +63,23 @@ asciidoctor {
 	dependsOn test
 }
 
-bootJar {
-	dependsOn asciidoctor
-	from ("${asciidoctor.outputDir}/html5") { // 왜인지 모르겠지만 동작을 하지 않음
-		into 'static/docs'
-	}
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
 
+asciidoctor.doLast {
 	copy {
 		from './build/docs/asciidoc'
 		include "*.html"
+		into 'build/resources/main/static/docs'
 		into 'src/main/resources/static/docs'
+	}
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") { // 왜인지 모르겠지만 동작을 하지 않음 하.... Gradle 이 이상해요
+		into 'static/docs'
 	}
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -3,7 +3,6 @@ plugins {
 	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.4'
 	id "org.asciidoctor.jvm.convert" version "3.3.2"
-
 }
 
 group = 'com.da-ily'
@@ -64,13 +63,27 @@ asciidoctor {
 	dependsOn test
 }
 
-task copySubmoduleYml(type: Copy) {
+bootJar {
+	dependsOn asciidoctor
+	from ("${asciidoctor.outputDir}/html5") { // 왜인지 모르겠지만 동작을 하지 않음
+		into 'static/docs'
+	}
+
+	copy {
+		from './build/docs/asciidoc'
+		include "*.html"
+		into 'src/main/resources/static/docs'
+	}
+}
+
+tasks.register('copySubmoduleYml', Copy) {
 	copy {
 		from './submodule'
 		include "*.yml"
 		into 'src/main/resources'
 	}
 }
+
 
 jar {
 	enabled = false

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
+
 }
 
 group = 'com.da-ily'
@@ -12,6 +14,7 @@ java {
 }
 
 configurations {
+	asciidoctorExt
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -29,6 +32,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	//jwt library
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
@@ -44,8 +49,19 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 }
 
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
 tasks.named('test') {
+	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+asciidoctor {
+	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
+	dependsOn test
 }
 
 task copySubmoduleYml(type: Copy) {

--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -4,27 +4,27 @@
 
 = 다일리 API 문서
 
-// === 예외 케이스 응답
+=== 예외 케이스 공통 응답
 
-// [source]
-// ----
-// {
-//     "successful": false
-//     "msg": 예외 메시지
-//     "statusCode": 상태코드
-// }
-// ----
-//
-// 예시
-//
-// [source]
-// ----
-// {
-//     "successful": false
-//     "msg": 해당 회원을 찾을 수 없습니다.
-//     "statusCode": 404
-// }
-// ----
+[source,json]
+----
+{
+    "successful": false,
+    "msg": "예외 메시지",
+    "statusCode": 상태코드
+}
+----
+
+==== 예시
+
+[source, json]
+----
+{
+    "successful": false,
+    "msg": "해당 회원을 찾을 수 없습니다.",
+    "statusCode": 404
+}
+----
 
 == 인증 & 인가
 

--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -1,0 +1,45 @@
+= 다일리 API 문서
+
+== 인증 & 인가
+
+== 회원
+
+=== 회원가입
+
+
+
+==== 요청
+
+include::{snippets}/회원가입/http-request.adoc[]
+include::{snippets}/회원가입/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/회원가입/http-response.adoc[]
+include::{snippets}/회원가입/response-fields.adoc[]
+
+
+=== 회원정보 조회
+
+=== 아이디 중복 확인
+
+=== 닉네임 중복 확인
+
+=== 닉네임 수정
+
+=== 이메일 인증번호 전송
+
+=== 이메일 인증번호 검증 & 이메일 등록
+
+=== 아이디 찾기
+
+=== 비밀번호 변경 (마이페이지)
+
+=== 비밀번호 변경 (비밀번호 찾기)
+
+
+// include::{snippets}/register/http-request.adoc[]
+// include::{snippets}/register/http-response.adoc[]
+// include::{snippets}/register/httpie-request.adoc[]
+// include::{snippets}/register/request-body.adoc[]
+// include::{snippets}/register/response-body.adoc[]

--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -1,4 +1,30 @@
+:toc: left
+:source-highlighter: highlightjs
+
+
 = 다일리 API 문서
+
+// === 예외 케이스 응답
+
+// [source]
+// ----
+// {
+//     "successful": false
+//     "msg": 예외 메시지
+//     "statusCode": 상태코드
+// }
+// ----
+//
+// 예시
+//
+// [source]
+// ----
+// {
+//     "successful": false
+//     "msg": 해당 회원을 찾을 수 없습니다.
+//     "statusCode": 404
+// }
+// ----
 
 == 인증 & 인가
 
@@ -29,7 +55,6 @@ include::{snippets}/회원가입/request-fields.adoc[]
 include::{snippets}/회원가입/http-response.adoc[]
 include::{snippets}/회원가입/response-fields.adoc[]
 
-
 === 회원정보 조회
 
 ==== 요청
@@ -49,6 +74,10 @@ include::{snippets}/아이디중복검사/http-request.adoc[]
 include::{snippets}/아이디중복검사/query-parameters.adoc[]
 
 ==== 응답
+
+include::{snippets}/아이디중복검사/http-response.adoc[]
+include::{snippets}/아이디중복검사/response-fields.adoc[]
+
 
 === 닉네임 중복 검사
 
@@ -84,7 +113,6 @@ include::{snippets}/이메일인증번호전송/request-fields.adoc[]
 ==== 응답
 
 include::{snippets}/이메일인증번호전송/http-response.adoc[]
-include::{snippets}/이메일인증번호전송/response-fields.adoc[]
 
 === 이메일 인증번호 검증 & 이메일 등록
 
@@ -96,7 +124,6 @@ include::{snippets}/이메일인증번호검증및등록/request-fields.adoc[]
 ==== 응답
 
 include::{snippets}/이메일인증번호검증및등록/http-response.adoc[]
-include::{snippets}/이메일인증번호검증및등록/response-fields.adoc[]
 
 === 아이디 찾기
 
@@ -110,7 +137,6 @@ include::{snippets}/회원비밀번호변경/request-fields.adoc[]
 ==== 응답
 
 include::{snippets}/회원비밀번호변경/http-response.adoc[]
-include::{snippets}/회원비밀번호변경/response-fields.adoc[]
 
 === 비밀번호 변경 (비밀번호 찾기)
 
@@ -122,7 +148,6 @@ include::{snippets}/회원비밀번호변경_비밀번호찾기/request-fields.a
 ==== 응답
 
 include::{snippets}/회원비밀번호변경_비밀번호찾기/http-response.adoc[]
-include::{snippets}/회원비밀번호변경_비밀번호찾기/response-fields.adoc[]
 
 
 

--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -2,11 +2,22 @@
 
 == 인증 & 인가
 
+=== 로그인
+
+=== 로그아웃
+
+
+
+
+
+//--------------------회원 시작--------------------------------//
+
 == 회원
 
+
+
+
 === 회원가입
-
-
 
 ==== 요청
 
@@ -21,22 +32,111 @@ include::{snippets}/회원가입/response-fields.adoc[]
 
 === 회원정보 조회
 
-=== 아이디 중복 확인
+==== 요청
 
-=== 닉네임 중복 확인
+include::{snippets}/회원정보조회/http-request.adoc[]
 
-=== 닉네임 수정
+==== 응답
+
+include::{snippets}/회원가입/http-response.adoc[]
+include::{snippets}/회원가입/response-fields.adoc[]
+
+=== 아이디 중복 검사
+
+==== 요청
+
+include::{snippets}/아이디중복검사/http-request.adoc[]
+include::{snippets}/아이디중복검사/query-parameters.adoc[]
+
+==== 응답
+
+=== 닉네임 중복 검사
+
+==== 요청
+
+include::{snippets}/닉네임중복검사/http-request.adoc[]
+include::{snippets}/닉네임중복검사/query-parameters.adoc[]
+
+==== 응답
+
+include::{snippets}/닉네임중복검사/http-response.adoc[]
+include::{snippets}/닉네임중복검사/response-fields.adoc[]
+
+=== 닉네임 변경
+
+==== 요청
+
+include::{snippets}/회원닉네임변경/http-request.adoc[]
+include::{snippets}/회원닉네임변경/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/회원닉네임변경/http-response.adoc[]
+include::{snippets}/회원닉네임변경/response-fields.adoc[]
 
 === 이메일 인증번호 전송
 
+==== 요청
+
+include::{snippets}/이메일인증번호전송/http-request.adoc[]
+include::{snippets}/이메일인증번호전송/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/이메일인증번호전송/http-response.adoc[]
+include::{snippets}/이메일인증번호전송/response-fields.adoc[]
+
 === 이메일 인증번호 검증 & 이메일 등록
+
+==== 요청
+
+include::{snippets}/이메일인증번호검증및등록/http-request.adoc[]
+include::{snippets}/이메일인증번호검증및등록/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/이메일인증번호검증및등록/http-response.adoc[]
+include::{snippets}/이메일인증번호검증및등록/response-fields.adoc[]
 
 === 아이디 찾기
 
 === 비밀번호 변경 (마이페이지)
 
+==== 요청
+
+include::{snippets}/회원비밀번호변경/http-request.adoc[]
+include::{snippets}/회원비밀번호변경/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/회원비밀번호변경/http-response.adoc[]
+include::{snippets}/회원비밀번호변경/response-fields.adoc[]
+
 === 비밀번호 변경 (비밀번호 찾기)
 
+==== 요청
+
+include::{snippets}/회원비밀번호변경_비밀번호찾기/http-request.adoc[]
+include::{snippets}/회원비밀번호변경_비밀번호찾기/request-fields.adoc[]
+
+==== 응답
+
+include::{snippets}/회원비밀번호변경_비밀번호찾기/http-response.adoc[]
+include::{snippets}/회원비밀번호변경_비밀번호찾기/response-fields.adoc[]
+
+
+
+//--------------------회원 종료--------------------------------//
+
+
+
+
+
+
+
+== 다일리
+
+== 커뮤니티
 
 // include::{snippets}/register/http-request.adoc[]
 // include::{snippets}/register/http-response.adoc[]

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -446,14 +446,14 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_회원가입">회원가입</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/member/join?_csrf=7VTLqkaF8t0yF_mciXWheOAghfvdNs7XiLLMsqBsSPKD6kqo2zWvnn-1x-4fc5ip6FiVHYNEqJm4Avf67oav0JYKK8Ln332f' -i -X POST \
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/member/join?_csrf=1XPTJkC9ZzFS7qoOMh0tdmTv1bYZ4TKa2isg7Cmnq5U2b3Tc4EW3RyWMAlJ_1p5tVjAZE1aK-I4uhAa340pBiBCUmvZUDBHl' -i -X POST \
     -H 'Content-Type: application/json;charset=UTF-8' \
     -d '{"username":"geonwoo123","password":"pass1234","nickname":null}'</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/join?_csrf=7VTLqkaF8t0yF_mciXWheOAghfvdNs7XiLLMsqBsSPKD6kqo2zWvnn-1x-4fc5ip6FiVHYNEqJm4Avf67oav0JYKK8Ln332f HTTP/1.1
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/join?_csrf=1XPTJkC9ZzFS7qoOMh0tdmTv1bYZ4TKa2isg7Cmnq5U2b3Tc4EW3RyWMAlJ_1p5tVjAZE1aK-I4uhAa340pBiBCUmvZUDBHl HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 63
 Host: localhost:8080
@@ -481,7 +481,7 @@ Content-Length: 74
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ echo '{"username":"geonwoo123","password":"pass1234","nickname":null}' | http POST 'http://localhost:8080/api/member/join?_csrf=7VTLqkaF8t0yF_mciXWheOAghfvdNs7XiLLMsqBsSPKD6kqo2zWvnn-1x-4fc5ip6FiVHYNEqJm4Avf67oav0JYKK8Ln332f' \
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ echo '{"username":"geonwoo123","password":"pass1234","nickname":null}' | http POST 'http://localhost:8080/api/member/join?_csrf=1XPTJkC9ZzFS7qoOMh0tdmTv1bYZ4TKa2isg7Cmnq5U2b3Tc4EW3RyWMAlJ_1p5tVjAZE1aK-I4uhAa340pBiBCUmvZUDBHl' \
     'Content-Type:application/json;charset=UTF-8'</code></pre>
 </div>
 </div>

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -435,12 +435,40 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>다일리 API 문서</h1>
 <div class="details">
 <span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_인증_인가">인증 &amp; 인가</a>
+<ul class="sectlevel2">
+<li><a href="#_로그인">로그인</a></li>
+<li><a href="#_로그아웃">로그아웃</a></li>
+</ul>
+</li>
+<li><a href="#_회원">회원</a>
+<ul class="sectlevel2">
+<li><a href="#_회원가입">회원가입</a></li>
+<li><a href="#_회원정보_조회">회원정보 조회</a></li>
+<li><a href="#_아이디_중복_검사">아이디 중복 검사</a></li>
+<li><a href="#_닉네임_중복_검사">닉네임 중복 검사</a></li>
+<li><a href="#_닉네임_변경">닉네임 변경</a></li>
+<li><a href="#_이메일_인증번호_전송">이메일 인증번호 전송</a></li>
+<li><a href="#_이메일_인증번호_검증_이메일_등록">이메일 인증번호 검증 &amp; 이메일 등록</a></li>
+<li><a href="#_아이디_찾기">아이디 찾기</a></li>
+<li><a href="#_비밀번호_변경_마이페이지">비밀번호 변경 (마이페이지)</a></li>
+<li><a href="#_비밀번호_변경_비밀번호_찾기">비밀번호 변경 (비밀번호 찾기)</a></li>
+</ul>
+</li>
+<li><a href="#_다일리">다일리</a></li>
+<li><a href="#_커뮤니티">커뮤니티</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
@@ -466,7 +494,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_요청">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/join?_csrf=ZjKlYhohyZLGY1huthrVkBjixp7DFD-kYaK9t-6AbjgNkT8wUFbAWigR_qrrUjwIhDfh8SnR66aid1uJU5Hc0tvmDF4-pwZU HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/join HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -517,7 +545,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -578,8 +606,8 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_2">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/member?_csrf=L0fhHk7eboqusvKmgehtS1CeB2x5ob5W6hiwXfmegXXitavXTHOEf3zsCrOD0cWX5MVZeGivKlQbwIl73X6DaM6n4hbVgZyy HTTP/1.1
-Authorization: JwtAccessToken</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member HTTP/1.1
+Authorization: Bearer AccessToken</code></pre>
 </div>
 </div>
 </div>
@@ -587,7 +615,7 @@ Authorization: JwtAccessToken</code></pre>
 <h4 id="_응답_2">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -648,7 +676,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_3">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/member/check-username?username=username123 HTTP/1.1</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-username?username=username123 HTTP/1.1</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -675,7 +703,40 @@ Content-Type: application/json;charset=UTF-8
 </div>
 <div class="sect3">
 <h4 id="_응답_3">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
 
+{
+  "duplicated" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>duplicated</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중복 여부</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div class="sect2">
@@ -684,7 +745,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_4">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/member/check-nickname?nickname=nickname HTTP/1.1</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-nickname?nickname=nickname HTTP/1.1</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -713,7 +774,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답_4">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -753,8 +814,9 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_5">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/member/nickname?_csrf=acVR6KxBj6VFmtezakf_MnSt1eMz8_-U5Gwm5ZzLtPxANb2NCPJn3JwjvMForrHQXmrLU0Sa-NsKysa5hlkUga7-0MokUd7o HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/nickname HTTP/1.1
 Content-Type: application/json;charset=UTF-8
+Authorization: Bearer AccessToken
 
 {
   "nickname" : "mynickname"
@@ -790,7 +852,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답_5">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -851,8 +913,9 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_6">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/email-verification/request?_csrf=8hHzHwB2PoeMC5D_yAxiV7ZoY2f3jrtSWtaD-NgW76xwRvcXwSWXejFFCrChbqHJ_iFWMtAJTgaWuY5_P-60wOwj15tEcZYv HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/email-verification/request HTTP/1.1
 Content-Type: application/json;charset=UTF-8
+Authorization: Bearer AccessToken
 
 {
   "email" : "qkrrjsdn123@naver.com"
@@ -888,7 +951,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답_6">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -897,36 +960,6 @@ Content-Type: application/json;charset=UTF-8
 }</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 </div>
 <div class="sect2">
@@ -935,8 +968,9 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_7">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/email-verification/confirm?_csrf=2JLqnHSIFsg9r0UlIqx4KSeWIpwViHNHk5zBejGtdKLhWmhs4fOOrhe4cvgQm3ERFoFMSEKmD6QjuEFqo__5SVedQpPTPA0O HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/email-verification/confirm HTTP/1.1
 Content-Type: application/json;charset=UTF-8
+Authorization: Bearer AccessToken
 
 {
   "email" : "qkrrjsdn123@naver.com",
@@ -979,7 +1013,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답_7">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -988,36 +1022,6 @@ Content-Type: application/json;charset=UTF-8
 }</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 </div>
 <div class="sect2">
@@ -1030,8 +1034,9 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_8">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/member/password?_csrf=gNt4K8w79d3RhmMxIadToDVPmFivRvUsC4an8tKZ_ep5UWUPtO5PTvVfxer8sFcER4pnkgUutWCdJMMBPuTCyrf_n95NaQE9 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
+Authorization: Bearer AccessToken
 
 {
   "presentPassword" : "12345678",
@@ -1074,7 +1079,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답_8">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -1083,36 +1088,6 @@ Content-Type: application/json;charset=UTF-8
 }</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 </div>
 <div class="sect2">
@@ -1121,7 +1096,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_요청_9">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/member/recover-password?_csrf=gOt0mvTMaA9dBqi5VhzkH9j9zTqMGoG-XOvipkSyvkDetMvQuY5Bqpf5CWxwZZnYNDHQJ7nL4Fi8eOOTaY_Wx3WBinfr0qji HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/recover-password HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -1165,7 +1140,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_응답_9">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -1174,36 +1149,6 @@ Content-Type: application/json;charset=UTF-8
 }</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 </div>
 </div>
@@ -1224,8 +1169,15 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-12-31 19:27:21 +0900
+Last updated 2024-01-01 01:10:52 +0900
 </div>
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
+<script>
+if (!hljs.initHighlighting.called) {
+  hljs.initHighlighting.called = true
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
+}
+</script>
 </body>
 </html>

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -445,7 +445,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
-<ul class="sectlevel1">
+<ul class="sectlevel2">
+<li><a href="#_예외_케이스_공통_응답">예외 케이스 공통 응답</a></li>
 <li><a href="#_인증_인가">인증 &amp; 인가</a>
 <ul class="sectlevel2">
 <li><a href="#_로그인">로그인</a></li>
@@ -472,6 +473,30 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 </div>
 <div id="content">
+<div class="sect2">
+<h3 id="_예외_케이스_공통_응답">예외 케이스 공통 응답</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-json hljs" data-lang="json">{
+    "successful": false,
+    "msg": "예외 메시지",
+    "statusCode": 상태코드
+}</code></pre>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_예시">예시</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-json hljs" data-lang="json">{
+    "successful": false,
+    "msg": "해당 회원을 찾을 수 없습니다.",
+    "statusCode": 404
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 <div class="sect1">
 <h2 id="_인증_인가">인증 &amp; 인가</h2>
 <div class="sectionbody">
@@ -1169,7 +1194,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-01 01:10:52 +0900
+Last updated 2024-01-01 02:42:33 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.18">
-<title>1. CREATE USER</title>
+<title>다일리 API 문서</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -438,70 +438,793 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="article">
 <div id="header">
+<h1>다일리 API 문서</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
 </div>
 <div id="content">
+<div class="sect1">
+<h2 id="_인증_인가">인증 &amp; 인가</h2>
+<div class="sectionbody">
 <div class="sect2">
-<h3 id="_1_create_user">1. CREATE USER</h3>
-<div class="sect3">
-<h4 id="_회원가입">회원가입</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/member/join?_csrf=1XPTJkC9ZzFS7qoOMh0tdmTv1bYZ4TKa2isg7Cmnq5U2b3Tc4EW3RyWMAlJ_1p5tVjAZE1aK-I4uhAa340pBiBCUmvZUDBHl' -i -X POST \
-    -H 'Content-Type: application/json;charset=UTF-8' \
-    -d '{"username":"geonwoo123","password":"pass1234","nickname":null}'</code></pre>
-</div>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/join?_csrf=1XPTJkC9ZzFS7qoOMh0tdmTv1bYZ4TKa2isg7Cmnq5U2b3Tc4EW3RyWMAlJ_1p5tVjAZE1aK-I4uhAa340pBiBCUmvZUDBHl HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Content-Length: 63
-Host: localhost:8080
+<h3 id="_로그인">로그인</h3>
 
-{"username":"geonwoo123","password":"pass1234","nickname":null}</code></pre>
+</div>
+<div class="sect2">
+<h3 id="_로그아웃">로그아웃</h3>
+
 </div>
 </div>
+</div>
+<div class="sect1">
+<h2 id="_회원">회원</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_회원가입">회원가입</h3>
+<div class="sect3">
+<h4 id="_요청">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/join?_csrf=ZjKlYhohyZLGY1huthrVkBjixp7DFD-kYaK9t-6AbjgNkT8wUFbAWigR_qrrUjwIhDfh8SnR66aid1uJU5Hc0tvmDF4-pwZU HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+
+{
+  "username" : "geonwoo123",
+  "password" : "pass1234",
+  "nickname" : "사모예드"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
 Content-Type: application/json;charset=UTF-8
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 0
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-X-Frame-Options: DENY
-Content-Length: 74
 
-{"id":1,"username":"geonwoo123","nickname":"난폭한사자","email":null}</code></pre>
+{
+  "id" : 1,
+  "username" : "geonwoo123",
+  "nickname" : "사모예드",
+  "email" : null
+}</code></pre>
 </div>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 식별 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_회원정보_조회">회원정보 조회</h3>
+<div class="sect3">
+<h4 id="_요청_2">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-bash" data-lang="bash">$ echo '{"username":"geonwoo123","password":"pass1234","nickname":null}' | http POST 'http://localhost:8080/api/member/join?_csrf=1XPTJkC9ZzFS7qoOMh0tdmTv1bYZ4TKa2isg7Cmnq5U2b3Tc4EW3RyWMAlJ_1p5tVjAZE1aK-I4uhAa340pBiBCUmvZUDBHl' \
-    'Content-Type:application/json;charset=UTF-8'</code></pre>
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/member?_csrf=L0fhHk7eboqusvKmgehtS1CeB2x5ob5W6hiwXfmegXXitavXTHOEf3zsCrOD0cWX5MVZeGivKlQbwIl73X6DaM6n4hbVgZyy HTTP/1.1
+Authorization: JwtAccessToken</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_응답_2">응답</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-json" data-lang="json">{"username":"geonwoo123","password":"pass1234","nickname":null}</code></pre>
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+
+{
+  "id" : 1,
+  "username" : "geonwoo123",
+  "nickname" : "사모예드",
+  "email" : null
+}</code></pre>
 </div>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 식별 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_아이디_중복_검사">아이디 중복 검사</h3>
+<div class="sect3">
+<h4 id="_요청_3">요청</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlight nowrap"><code class="language-json" data-lang="json">{"id":1,"username":"geonwoo123","nickname":"난폭한사자","email":null}</code></pre>
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/member/check-username?username=username123 HTTP/1.1</code></pre>
 </div>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중복검사를 요청할 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_3">응답</h4>
+
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_중복_검사">닉네임 중복 검사</h3>
+<div class="sect3">
+<h4 id="_요청_4">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /api/member/check-nickname?nickname=nickname HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중복검사를 요청할 닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_4">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "duplicated" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>duplicated</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중복 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_변경">닉네임 변경</h3>
+<div class="sect3">
+<h4 id="_요청_5">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/member/nickname?_csrf=acVR6KxBj6VFmtezakf_MnSt1eMz8_-U5Gwm5ZzLtPxANb2NCPJn3JwjvMForrHQXmrLU0Sa-NsKysa5hlkUga7-0MokUd7o HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+
+{
+  "nickname" : "mynickname"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">변경을 요청할 닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_5">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "id" : 1,
+  "username" : "geonwoo123",
+  "nickname" : "난폭한사자",
+  "email" : null
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 식별 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_이메일_인증번호_전송">이메일 인증번호 전송</h3>
+<div class="sect3">
+<h4 id="_요청_6">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/email-verification/request?_csrf=8hHzHwB2PoeMC5D_yAxiV7ZoY2f3jrtSWtaD-NgW76xwRvcXwSWXejFFCrChbqHJ_iFWMtAJTgaWuY5_P-60wOwj15tEcZYv HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+
+{
+  "email" : "qkrrjsdn123@naver.com"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_6">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_이메일_인증번호_검증_이메일_등록">이메일 인증번호 검증 &amp; 이메일 등록</h3>
+<div class="sect3">
+<h4 id="_요청_7">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/email-verification/confirm?_csrf=2JLqnHSIFsg9r0UlIqx4KSeWIpwViHNHk5zBejGtdKLhWmhs4fOOrhe4cvgQm3ERFoFMSEKmD6QjuEFqo__5SVedQpPTPA0O HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+
+{
+  "email" : "qkrrjsdn123@naver.com",
+  "certificationNumber" : "315162"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증번호 요청한 이메일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>certificationNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_7">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_아이디_찾기">아이디 찾기</h3>
+
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_변경_마이페이지">비밀번호 변경 (마이페이지)</h3>
+<div class="sect3">
+<h4 id="_요청_8">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/member/password?_csrf=gNt4K8w79d3RhmMxIadToDVPmFivRvUsC4an8tKZ_ep5UWUPtO5PTvVfxer8sFcER4pnkgUutWCdJMMBPuTCyrf_n95NaQE9 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+
+{
+  "presentPassword" : "12345678",
+  "updatePassword" : "23456789"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>presentPassword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 비밀번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>updatePassword</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">변경할 비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_8">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_변경_비밀번호_찾기">비밀번호 변경 (비밀번호 찾기)</h3>
+<div class="sect3">
+<h4 id="_요청_9">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PATCH /api/member/recover-password?_csrf=gOt0mvTMaA9dBqi5VhzkH9j9zTqMGoG-XOvipkSyvkDetMvQuY5Bqpf5CWxwZZnYNDHQJ7nL4Fi8eOOTaY_Wx3WBinfr0qji HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+
+{
+  "passwordResetToken" : "유효한 토큰",
+  "password" : "12345678"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>passwordResetToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호 변경 토큰</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">변경할 비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_9">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>successful</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_다일리">다일리</h2>
+<div class="sectionbody">
+
+</div>
+</div>
+<div class="sect1">
+<h2 id="_커뮤니티">커뮤니티</h2>
+<div class="sectionbody">
+
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-12-30 17:15:11 +0900
+Last updated 2023-12-31 19:27:21 +0900
 </div>
 </div>
 </body>

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>1. CREATE USER</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article">
+<div id="header">
+</div>
+<div id="content">
+<div class="sect2">
+<h3 id="_1_create_user">1. CREATE USER</h3>
+<div class="sect3">
+<h4 id="_회원가입">회원가입</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/api/member/join?_csrf=7VTLqkaF8t0yF_mciXWheOAghfvdNs7XiLLMsqBsSPKD6kqo2zWvnn-1x-4fc5ip6FiVHYNEqJm4Avf67oav0JYKK8Ln332f' -i -X POST \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d '{"username":"geonwoo123","password":"pass1234","nickname":null}'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/member/join?_csrf=7VTLqkaF8t0yF_mciXWheOAghfvdNs7XiLLMsqBsSPKD6kqo2zWvnn-1x-4fc5ip6FiVHYNEqJm4Avf67oav0JYKK8Ln332f HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 63
+Host: localhost:8080
+
+{"username":"geonwoo123","password":"pass1234","nickname":null}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json;charset=UTF-8
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 0
+Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+Pragma: no-cache
+Expires: 0
+X-Frame-Options: DENY
+Content-Length: 74
+
+{"id":1,"username":"geonwoo123","nickname":"난폭한사자","email":null}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-bash" data-lang="bash">$ echo '{"username":"geonwoo123","password":"pass1234","nickname":null}' | http POST 'http://localhost:8080/api/member/join?_csrf=7VTLqkaF8t0yF_mciXWheOAghfvdNs7XiLLMsqBsSPKD6kqo2zWvnn-1x-4fc5ip6FiVHYNEqJm4Avf67oav0JYKK8Ln332f' \
+    'Content-Type:application/json;charset=UTF-8'</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-json" data-lang="json">{"username":"geonwoo123","password":"pass1234","nickname":null}</code></pre>
+</div>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-json" data-lang="json">{"id":1,"username":"geonwoo123","nickname":"난폭한사자","email":null}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2023-12-30 17:15:11 +0900
+</div>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/member/controller/MemberControllerTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.setMaxStackTraceElementsDisplayed;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -46,6 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
 })
 @MockBean(JpaMetamodelMappingContext.class)
+
 class MemberControllerTest {
     @Autowired
     MockMvc mockMvc;

--- a/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
+++ b/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
@@ -4,22 +4,28 @@ import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.restdocs.snippet.Snippet;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
-public interface RestDocsUtil {
-    static OperationRequestPreprocessor customRequestPreprocessor() {
-        return preprocessRequest(modifyHeaders()
-                .remove("Content-Length")
-                .remove("Host"),
+public class RestDocsUtil {
+    private static OperationRequestPreprocessor customRequestPreprocessor() {
+        return preprocessRequest(
+                modifyHeaders()
+                        .remove("Content-Length")
+                        .remove("Host"),
                 prettyPrint());
     }
 
-    static OperationResponsePreprocessor customResponsePreprocessor() {
+    private static OperationResponsePreprocessor customResponsePreprocessor() {
         return preprocessResponse(modifyHeaders().remove("Vary")
                         .remove("Content-Length")
                         .remove("X-Content-Type-Options")
@@ -31,12 +37,19 @@ public interface RestDocsUtil {
                 prettyPrint());
     }
 
-    static RestDocumentationResultHandler document(String identifier, Snippet... snippets) {
+    public static RestDocumentationResultHandler document(String identifier, Snippet... snippets) {
         return MockMvcRestDocumentation.document(
                 identifier,
                 customRequestPreprocessor(),
                 customResponsePreprocessor(),
                 snippets);
+    }
+
+    public static ResponseFieldsSnippet commonSuccessResponseFields() {
+        return responseFields(
+                fieldWithPath("successful").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("statusCode").type(NUMBER).description("상태 코드")
+        );
     }
 }
 

--- a/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
+++ b/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
@@ -1,0 +1,45 @@
+package com.daily.daily.testutil.document;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+public interface ApiDocumentUtils {
+    static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                modifyUris()
+                        .scheme("https")
+                        .host("docs.api.com")
+                        .removePort(),
+                prettyPrint());
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(modifyHeaders().remove("Vary")
+                        .remove("Content-Length")
+                        .remove("X-Content-Type-Options")
+                        .remove("X-XSS-Protection")
+                        .remove("Cache-Control")
+                        .remove("Pragma")
+                        .remove("Expires")
+                        .remove("X-Frame-Options"),
+                prettyPrint());
+    }}
+
+//HTTP/1.1 201 Created
+//Vary: Origin
+//Vary: Access-Control-Request-Method
+//Vary: Access-Control-Request-Headers
+//Content-Type: application/json;charset=UTF-8
+//X-Content-Type-Options: nosniff
+//X-XSS-Protection: 0
+//Cache-Control: no-cache, no-store, max-age=0, must-revalidate
+//Pragma: no-cache
+//Expires: 0
+//X-Frame-Options: DENY
+//Content-Length: 97

--- a/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
+++ b/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
@@ -21,6 +21,7 @@ public class RestDocsUtil {
         return preprocessRequest(
                 modifyHeaders()
                         .remove("Content-Length")
+                        .remove("X-CSRF-TOKEN")
                         .remove("Host"),
                 prettyPrint());
     }
@@ -43,13 +44,6 @@ public class RestDocsUtil {
                 customRequestPreprocessor(),
                 customResponsePreprocessor(),
                 snippets);
-    }
-
-    public static ResponseFieldsSnippet commonSuccessResponseFields() {
-        return responseFields(
-                fieldWithPath("successful").type(BOOLEAN).description("성공 여부"),
-                fieldWithPath("statusCode").type(NUMBER).description("상태 코드")
-        );
     }
 }
 

--- a/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
+++ b/backend/src/test/java/com/daily/daily/testutil/document/RestDocsUtil.java
@@ -1,25 +1,25 @@
 package com.daily.daily.testutil.document;
 
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.snippet.Snippet;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyHeaders;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
-public interface ApiDocumentUtils {
-    static OperationRequestPreprocessor getDocumentRequest() {
-        return preprocessRequest(
-                modifyUris()
-                        .scheme("https")
-                        .host("docs.api.com")
-                        .removePort(),
+public interface RestDocsUtil {
+    static OperationRequestPreprocessor customRequestPreprocessor() {
+        return preprocessRequest(modifyHeaders()
+                .remove("Content-Length")
+                .remove("Host"),
                 prettyPrint());
     }
 
-    static OperationResponsePreprocessor getDocumentResponse() {
+    static OperationResponsePreprocessor customResponsePreprocessor() {
         return preprocessResponse(modifyHeaders().remove("Vary")
                         .remove("Content-Length")
                         .remove("X-Content-Type-Options")
@@ -29,7 +29,16 @@ public interface ApiDocumentUtils {
                         .remove("Expires")
                         .remove("X-Frame-Options"),
                 prettyPrint());
-    }}
+    }
+
+    static RestDocumentationResultHandler document(String identifier, Snippet... snippets) {
+        return MockMvcRestDocumentation.document(
+                identifier,
+                customRequestPreprocessor(),
+                customResponsePreprocessor(),
+                snippets);
+    }
+}
 
 //HTTP/1.1 201 Created
 //Vary: Origin

--- a/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcConstant.java
+++ b/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcConstant.java
@@ -1,0 +1,5 @@
+package com.daily.daily.testutil.mockmvc;
+
+public class MockMvcConstant {
+    public static final String AccessToken = "Bearer AccessToken";
+}

--- a/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcTest.java
+++ b/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcTest.java
@@ -1,0 +1,36 @@
+package com.daily.daily.testutil.mockmvc;
+
+import com.daily.daily.auth.jwt.JwtAuthorizationFilter;
+import com.daily.daily.auth.jwt.JwtUtil;
+import com.daily.daily.member.controller.MemberController;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+
+@WebMvcTest(
+        excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthorizationFilter.class),
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class),
+})
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+public class MockMvcTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected MockMvc authMockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+}

--- a/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcUtil.java
+++ b/backend/src/test/java/com/daily/daily/testutil/mockmvc/MockMvcUtil.java
@@ -1,0 +1,23 @@
+package com.daily.daily.testutil.mockmvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+public class MockMvcUtil {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static ResultActions doPost(MockMvc mockMvc, String path, Object dto) throws Exception {
+        return mockMvc.perform(post(path)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto))
+                .with(csrf())
+        );
+    }
+}

--- a/backend/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,10 @@
+|===
+|파라미터|필수값|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,11 @@
+|===
+|필드명|타입|필수값|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===

--- a/backend/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,11 @@
+|===
+|필드명|타입|필수값|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===


### PR DESCRIPTION
## 연관 이슈
close: #93 
## 작업 내용

- MemberController 파트를 RestDocs로 문서화 했습니다.
- 로그인 로그아웃은 Refresh토큰을 도입하면 다시 API문서가 변경되어야 할 것 같아서 안 했습니다.

## 의논할 거리

- 테스트코드 작성용 util 클래스를 만들었습니다.. 
  - RestDocsUtil 클래스를 만들었습니다.
  - MockMvcConstant, MockMvcTest, MockMvcUtil 등을 만들었는데 MockMvcTest와 MockMvcUtil 는 만들다가 썩 마음에 들지 않아서 사용하지 않고 있습니다. 중복 코드를 조금 제거하려는 목적으로 만들었는데, 추후에 조금 더 만져보고 별다른 수확이 없으면 지우겠습니다.
- 위키에 Restdocs 사용법을 올렸습니다. 나중에 문서화 할 때 참고해 주세요
- restdocs 관련된 몇 가지 이슈도 위키에 같이 정리해서 올렸습니다.

## Merge 전에 해야할 작업
## 기타
- 새해복 많이받으세요 ㅎㅇㅌ