### PR TITLE
defaultSuccessfulURL 제거

### DIFF
--- a/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/daily/daily/auth/config/SecurityConfig.java
@@ -25,7 +25,6 @@ import org.springframework.web.filter.CorsFilter;
 @EnableWebSecurity
 @EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
-//    private final CorsFilter corsFilter;
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final CustomOAuth2UserService principalOauth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
@@ -49,7 +48,6 @@ public class SecurityConfig {
                 .failureHandler(oAuth2FailureHandler)
                 .userInfoEndpoint(endpointConfig -> endpointConfig
                         .userService(principalOauth2UserService))
-                .defaultSuccessUrl("http://localhost:3000/")
         );
 
         return http.build();

--- a/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
@@ -27,7 +27,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             String refreshToken = jwtUtil.generateRefreshToken(oAuth2User.getMember().getId());
             response.addHeader(jwtUtil.getAccessHeader(), accessToken);
             response.addHeader(jwtUtil.getRefreshHeader(), refreshToken);
-            response.sendRedirect("/");
+            response.sendRedirect("http://localhost:3000");
             jwtUtil.sendAccessAndRefreshToken(response, accessToken, null);
         } catch (Exception e) {
             log.error("OAuth2 Login 성공 후 예외 발생", e);


### PR DESCRIPTION
## 연관 이슈
close: #118 
## 작업 내용
- defaultSuccessfulURL 제거
- OAuth2SuccessHandler 에서 소셜로그인 성공시 http://localhost:3000로 리다이렉트 하도록 설정
## 의논할 거리
## Merge 전에 해야할 작업
## 기타
괜히 붙여서 고생했네요.. 이렇게 예상치 못하게 동작할 줄은..
