### PR TITLE
로그인 성공시 토큰을 쿠키로 전달

### DIFF
--- a/backend/src/docs/asciidoc/api-document.adoc
+++ b/backend/src/docs/asciidoc/api-document.adoc
@@ -38,12 +38,18 @@ include::{snippets}/로그인/request-fields.adoc[]
 ==== 응답
 
 include::{snippets}/로그인/http-response.adoc[]
-include::{snippets}/로그인/response-headers.adoc[]
 
 === 로그아웃
 
+==== 요청
+
+include::{snippets}/로그아웃/http-request.adoc[]
 include::{snippets}/로그아웃/request-headers.adoc[]
+
+==== 응답
+
 include::{snippets}/로그아웃/http-response.adoc[]
+
 
 === access token 갱신
 

--- a/backend/src/main/java/com/daily/daily/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/daily/daily/auth/controller/AuthController.java
@@ -24,14 +24,15 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<CommonResponseDTO> login(@RequestBody LoginDTO loginDto, HttpServletResponse response) {
         TokenDTO tokenDto = authService.login(loginDto);
-        response.setHeader(jwtUtil.getAccessHeader(), tokenDto.getAccessToken());
-        response.setHeader(jwtUtil.getRefreshHeader(), tokenDto.getRefreshToken());
+
+        jwtUtil.setTokensInCookie(response, tokenDto.getAccessToken(), tokenDto.getRefreshToken());
+
         return ResponseEntity.ok().body(new CommonResponseDTO(true, HttpStatus.OK.value()));
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<CommonResponseDTO> logout(@RequestHeader("Authorization") String accessToken,
-                       @RequestHeader("Authorization-refresh") String refreshToken) {
+    public ResponseEntity<CommonResponseDTO> logout(@RequestHeader(JwtUtil.ACCESS_HEADER) String accessToken,
+                       @RequestHeader(JwtUtil.REFRESH_HEADER) String refreshToken) {
 
         authService.logout(TokenDTO.of(accessToken, refreshToken));
         return ResponseEntity.ok().body(new CommonResponseDTO(true, HttpStatus.OK.value()));

--- a/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
@@ -33,7 +33,7 @@ public class JwtUtil {
     //claim
     private static final String ROLE_CLAIM = "role";
     private static final String MEMBER_ID_CLAIM = "memberId";
-    //subject, cookie Key
+    //subject, cookie name
     private static final String ACCESS_TOKEN = "AccessToken";
     private static final String REFRESH_TOKEN = "RefreshToken";
 
@@ -73,7 +73,6 @@ public class JwtUtil {
                 .compact();
     }
 
-
     public boolean validateToken(String token) {
         try {
             Jwts.parser()
@@ -105,13 +104,6 @@ public class JwtUtil {
         MemberRole memberRole = MemberRole.valueOf(payload.get(ROLE_CLAIM, String.class));
 
         return new JwtClaimDTO(memberId, memberRole);
-    }
-
-    public String createRefreshToken() {
-        return JWT.create()
-                .withSubject(REFRESH_TOKEN)
-                .withExpiresAt(new Date(System.currentTimeMillis() + refreshTokenExpiration))
-                .sign(Algorithm.HMAC512(secretCode));
     }
 
     public void setTokensInCookie(HttpServletResponse response, String accessToken, String refreshToken) {

--- a/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
@@ -117,7 +117,7 @@ public class JwtUtil {
     private ResponseCookie createTokenCookie(String cookieName, String token) {
         return ResponseCookie.from(cookieName, token)
                 .path("/")
-                .secure(true)
+                .secure(false)
                 .httpOnly(false)
                 .build();
     }

--- a/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/daily/daily/auth/jwt/JwtUtil.java
@@ -20,6 +20,8 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+
 
 @Component
 @Slf4j
@@ -120,19 +122,18 @@ public class JwtUtil {
     }
 
     public void setTokensInCookie(HttpServletResponse response, String accessToken, String refreshToken) {
-        ResponseCookie accessCookie = ResponseCookie.from(ACCESS_TOKEN, accessToken)
+        ResponseCookie accessCookie = createTokenCookie(ACCESS_TOKEN, accessToken);
+        ResponseCookie refreshCookie = createTokenCookie(REFRESH_TOKEN, refreshToken);
+
+        response.addHeader(SET_COOKIE, accessCookie.toString());
+        response.addHeader(SET_COOKIE, refreshCookie.toString());
+    }
+
+    private ResponseCookie createTokenCookie(String cookieName, String token) {
+        return ResponseCookie.from(cookieName, token)
                 .path("/")
                 .secure(true)
                 .httpOnly(false)
                 .build();
-
-        ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_TOKEN, refreshToken)
-                .path("/")
-                .secure(true)
-                .httpOnly(false)
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
     }
 }

--- a/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/daily/daily/oauth/handler/OAuth2SuccessHandler.java
@@ -23,14 +23,15 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         try {
             OAuth2CustomUser oAuth2User = (OAuth2CustomUser) authentication.getPrincipal();
-            String accessToken = jwtUtil.generateAccessToken(oAuth2User.getMember().getId(),oAuth2User.getMember().getRole());
+
+            String accessToken = jwtUtil.generateAccessToken(oAuth2User.getMember().getId(), oAuth2User.getMember().getRole());
             String refreshToken = jwtUtil.generateRefreshToken(oAuth2User.getMember().getId());
-            response.addHeader(jwtUtil.getAccessHeader(), accessToken);
-            response.addHeader(jwtUtil.getRefreshHeader(), refreshToken);
+
+            jwtUtil.setTokensInCookie(response, accessToken, refreshToken);
+
             response.sendRedirect("http://localhost:3000");
-            jwtUtil.sendAccessAndRefreshToken(response, accessToken, null);
         } catch (Exception e) {
-            log.error("OAuth2 Login 성공 후 예외 발생", e);
+            log.error("OAuth2 Login 성공 후 예외 발생 : {}", e.getMessage());
         }
     }
 }

--- a/backend/src/main/resources/static/docs/api-document.html
+++ b/backend/src/main/resources/static/docs/api-document.html
@@ -553,8 +553,8 @@ Content-Type: application/json;charset=UTF-8
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNCwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA0NjM5MTkyfQ.G6xEFKrsCRyDj0MjsyM5hydA0mY8-yTB-Hi_OE1UZIqPl7onO2CSvleOHjx1S0cenWlw5aMKQ7uijU3z1FoJdA
-Authorization-refresh: Bearer eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTQsImlhdCI6MTcwNDYzNTU5MiwiZXhwIjoxNzA1ODQ1MTkyfQ.trsGVQTq49cN54t8jcDmP_fx8cuzZSM3LbRF6R_0mBp99PAV2m0TR76ZPtqauxNfCv4xrqBzsT_hG4ruMV-vdw
+Set-Cookie: AccessToken=eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoxNCwicm9sZSI6IlJPTEVfTUVNQkVSIiwiZXhwIjoxNzA0Njk2NjY4fQ.leflqpEQAQblroNHfxAWJxvQyU2Fk1RMqLR2wJ2aTqQWzLEGXobPi7C0kqvXWz7ke2WB7XcDNnNAiSBEVHMwNw; Path=/; Secure
+Set-Cookie: RefreshToken=eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MTQsImlhdCI6MTcwNDY5MzA2OCwiZXhwIjoxNzA1OTAyNjY4fQ.41uxpfA4rebfxrgv-qN7ion0FM951WTZWheu5E_X3GqgD0aLXNAqgIHcn5tFVqno078ivS9dfvW2T1zlZSTbhg; Path=/; Secure
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -563,32 +563,20 @@ Content-Type: application/json;charset=UTF-8
 }</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization-refresh</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">refreshToken</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 </div>
 <div class="sect2">
 <h3 id="_로그아웃">로그아웃</h3>
+<div class="sect3">
+<h4 id="_요청_2">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/logout HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjoyLCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ2OTY2NjZ9.yYEiZizAwoMTuJ1Yr9sd5LT2HE_MlgU12aglutTEYZNTWdIL6tIWnRlkdL07JtBwocHSbY7eknX31E0NnyCxNQ
+Authorization-refresh: eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6MiwiaWF0IjoxNzA0NjkzMDY3LCJleHAiOjE3MDU5MDI2Njd9.kxmV95k03LEg_lYDf-2BmrTTHaTnjQ_bBhiihX0c9yV55_QlFgT82wVHk7Gl_i0cA34kIiF929HmAQNLfjtMLQ</code></pre>
+</div>
+</div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -612,17 +600,32 @@ Content-Type: application/json;charset=UTF-8
 </tbody>
 </table>
 </div>
+<div class="sect3">
+<h4 id="_응답_2">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "statusCode" : 200,
+  "successful" : true
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 <div class="sect2">
 <h3 id="_access_token_갱신">access token 갱신</h3>
 <div class="sect3">
-<h4 id="_요청_2">요청</h4>
+<h4 id="_요청_3">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/token HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 
 {
-  "refreshToken" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA0NjM1NTkxLCJleHAiOjE3MDU4NDUxOTF9.IwZYLxpjaNr0EasGugki2fsMjPC9ecWXOwgkTv9vhnlKNx6CwUMeNaLYmPyIJFRMrmq5bA17T1VXdmUJ_EM4cA"
+  "refreshToken" : "eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA0NjkzMDY3LCJleHAiOjE3MDU5MDI2Njd9.UpIek0hVJ2NbpGFbY1VLNohbC4RGOPlfQA7bjDv71R11potlow6B0qXjgtgbPE2tUxMxfXoadnVdZM0OaTj_gA"
 }</code></pre>
 </div>
 </div>
@@ -652,15 +655,15 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_2">응답</h4>
+<h4 id="_응답_3">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 
 {
-  "accessToken" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo4LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ2MzkxOTF9.ERE_YF6ec2ZafQyXCtAm6bsMoqByXsJAmKCp2yh8m7q1Z1bth7loHgoAcGIv-x9eoPx5kWXfRxZszqvREpxh8w",
-  "refreshToken" : "Bearer eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA0NjM1NTkxLCJleHAiOjE3MDU4NDUxOTF9.IwZYLxpjaNr0EasGugki2fsMjPC9ecWXOwgkTv9vhnlKNx6CwUMeNaLYmPyIJFRMrmq5bA17T1VXdmUJ_EM4cA"
+  "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJpc3MiOiJodHRwczovL2RhaWx5LmNvbSIsIm1lbWJlcklkIjo4LCJyb2xlIjoiUk9MRV9NRU1CRVIiLCJleHAiOjE3MDQ2OTY2Njd9.k8-cJ9GC-jvAxPt-JYZQc9LzgvXiWEcyZLIgs0z_8IvXs0dCImBN2ukOAhJNcr8ECnc1bdbPIXKN3OtELW423A",
+  "refreshToken" : "eyJhbGciOiJIUzUxMiJ9.eyJtZW1iZXJJZCI6OCwiaWF0IjoxNzA0NjkzMDY3LCJleHAiOjE3MDU5MDI2Njd9.UpIek0hVJ2NbpGFbY1VLNohbC4RGOPlfQA7bjDv71R11potlow6B0qXjgtgbPE2tUxMxfXoadnVdZM0OaTj_gA"
 }</code></pre>
 </div>
 </div>
@@ -704,7 +707,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_회원가입">회원가입</h3>
 <div class="sect3">
-<h4 id="_요청_3">요청</h4>
+<h4 id="_요청_4">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/join HTTP/1.1
@@ -753,76 +756,6 @@ Content-Type: application/json;charset=UTF-8
 </tr>
 </tbody>
 </table>
-</div>
-<div class="sect3">
-<h4 id="_응답_3">응답</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
-
-{
-  "id" : 1,
-  "username" : "geonwoo123",
-  "nickname" : "사모예드",
-  "email" : null
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원 식별 id</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">아이디</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_회원정보_조회">회원정보 조회</h3>
-<div class="sect3">
-<h4 id="_요청_4">요청</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member HTTP/1.1
-Authorization: Bearer AccessToken</code></pre>
-</div>
-</div>
 </div>
 <div class="sect3">
 <h4 id="_응답_4">응답</h4>
@@ -884,9 +817,79 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_아이디_중복_검사">아이디 중복 검사</h3>
+<h3 id="_회원정보_조회">회원정보 조회</h3>
 <div class="sect3">
 <h4 id="_요청_5">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member HTTP/1.1
+Authorization: Bearer AccessToken</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_응답_5">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+
+{
+  "id" : 1,
+  "username" : "geonwoo123",
+  "nickname" : "사모예드",
+  "email" : null
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 식별 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_아이디_중복_검사">아이디 중복 검사</h3>
+<div class="sect3">
+<h4 id="_요청_6">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-username?username=username123 HTTP/1.1</code></pre>
@@ -910,75 +913,6 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>username</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">중복검사를 요청할 아이디</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_응답_5">응답</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "duplicated" : true
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>duplicated</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">중복 여부</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_닉네임_중복_검사">닉네임 중복 검사</h3>
-<div class="sect3">
-<h4 id="_요청_6">요청</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-nickname?nickname=nickname HTTP/1.1</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">중복검사를 요청할 닉네임</p></td>
 </tr>
 </tbody>
 </table>
@@ -1022,9 +956,78 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_닉네임_변경">닉네임 변경</h3>
+<h3 id="_닉네임_중복_검사">닉네임 중복 검사</h3>
 <div class="sect3">
 <h4 id="_요청_7">요청</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/member/check-nickname?nickname=nickname HTTP/1.1</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중복검사를 요청할 닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_응답_7">응답</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "duplicated" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>duplicated</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중복 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_변경">닉네임 변경</h3>
+<div class="sect3">
+<h4 id="_요청_8">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/nickname HTTP/1.1
@@ -1062,7 +1065,7 @@ Authorization: Bearer AccessToken
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_7">응답</h4>
+<h4 id="_응답_8">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1123,7 +1126,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_비밀번호_변경_마이페이지">비밀번호 변경 (마이페이지)</h3>
 <div class="sect3">
-<h4 id="_요청_8">요청</h4>
+<h4 id="_요청_9">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/password HTTP/1.1
@@ -1168,7 +1171,7 @@ Authorization: Bearer AccessToken
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_8">응답</h4>
+<h4 id="_응답_9">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1185,7 +1188,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_이메일_인증번호_전송">이메일 인증번호 전송</h3>
 <div class="sect3">
-<h4 id="_요청_9">요청</h4>
+<h4 id="_요청_10">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/email-verification/request HTTP/1.1
@@ -1223,7 +1226,7 @@ Authorization: Bearer AccessToken
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_9">응답</h4>
+<h4 id="_응답_10">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1240,7 +1243,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_이메일_인증번호_검증_이메일_등록">이메일 인증번호 검증 &amp; 이메일 등록</h3>
 <div class="sect3">
-<h4 id="_요청_10">요청</h4>
+<h4 id="_요청_11">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/email-verification/confirm HTTP/1.1
@@ -1285,7 +1288,7 @@ Authorization: Bearer AccessToken
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_10">응답</h4>
+<h4 id="_응답_11">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1302,7 +1305,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_아이디_찾기">아이디 찾기</h3>
 <div class="sect3">
-<h4 id="_요청_11">요청</h4>
+<h4 id="_요청_12">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/recover-username HTTP/1.1
@@ -1339,7 +1342,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_11">응답</h4>
+<h4 id="_응답_12">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1356,7 +1359,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_비밀번호_변경링크_전송">비밀번호 변경링크 전송</h3>
 <div class="sect3">
-<h4 id="_요청_12">요청</h4>
+<h4 id="_요청_13">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/member/recover-password HTTP/1.1
@@ -1400,7 +1403,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_12">응답</h4>
+<h4 id="_응답_13">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1417,7 +1420,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_비밀번호_변경_비밀번호_찾기">비밀번호 변경 (비밀번호 찾기)</h3>
 <div class="sect3">
-<h4 id="_요청_13">요청</h4>
+<h4 id="_요청_14">요청</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/member/recover-password HTTP/1.1
@@ -1461,7 +1464,7 @@ Content-Type: application/json;charset=UTF-8
 </table>
 </div>
 <div class="sect3">
-<h4 id="_응답_13">응답</h4>
+<h4 id="_응답_14">응답</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1493,7 +1496,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-01-07 22:48:40 +0900
+Last updated 2024-01-08 14:40:39 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/backend/src/test/java/com/daily/daily/integration/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/daily/daily/integration/auth/controller/AuthControllerTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import static com.daily.daily.testutil.document.RestDocsUtil.document;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -113,16 +114,13 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(loginDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.statusCode").value(200))
-                .andExpect(header().exists("Authorization"));
+                .andExpect(cookie().exists("AccessToken"))
+                .andExpect(cookie().exists("RefreshToken"));
 
         resultActions.andDo(document("로그인",
                 requestFields(
                         fieldWithPath("username").type(STRING).description("아이디"),
                         fieldWithPath("password").type(STRING).description("비밀번호")
-                ),
-                responseHeaders(
-                        headerWithName("Authorization").description("accessToken"),
-                        headerWithName("Authorization-refresh").description("refreshToken")
                 ),
                 responseFields(
                         fieldWithPath("statusCode").type(NUMBER).description("상태코드"),

--- a/backend/src/test/java/com/daily/daily/integration/auth/jwt/JwtUtilTest.java
+++ b/backend/src/test/java/com/daily/daily/integration/auth/jwt/JwtUtilTest.java
@@ -7,6 +7,7 @@ import com.daily.daily.member.constant.MemberRole;
 import com.daily.daily.member.controller.MemberController;
 import com.daily.daily.member.dto.JoinDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -42,33 +44,20 @@ public class JwtUtilTest {
     MemberController memberController;
 
     @Test
-    @DisplayName("jwt 토큰 생성이 완료됐는지 확인합니다.")
-    void createJwt() {
-
-        //given
-        Long id = 15L;
-        MemberRole role = MemberRole.ROLE_MEMBER;
-        //when
-        String jwtToken = jwtUtil.generateAccessToken(id, role);
-        System.out.println("jwtToken: " + jwtToken);
-
-        //then
-        assertThat(jwtToken.startsWith(JwtUtil.BEARER_PREFIX));
-    }
-
-    @Test
-    @DisplayName("토큰의 헤더가 제대로 나오는지 확인합니다.")
+    @DisplayName("Http 응답으로 전송되는 토큰이, jwtUtil 에서 만들어진 토큰과 같은 것인지 확인한다.")
     void checkTokenHeader() {
-        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
 
         String accessToken = jwtUtil.generateAccessToken(3L, MemberRole.ROLE_MEMBER);
         String refreshToken = jwtUtil.createRefreshToken();
 
-        jwtUtil.setAccessTokenHeader(mockHttpServletResponse, accessToken);
-        jwtUtil.sendAccessAndRefreshToken(mockHttpServletResponse,accessToken,refreshToken);
-        String headerAccessToken = mockHttpServletResponse.getHeader("Authorization");
+        jwtUtil.setTokensInCookie(mockResponse, accessToken, refreshToken);
 
-        assertThat(headerAccessToken).isEqualTo(accessToken);
+        String responseAccessToken = mockResponse.getCookie("AccessToken").getValue();
+        String responseRefreshToken = mockResponse.getCookie("RefreshToken").getValue();
+
+        assertThat(accessToken).isEqualTo(responseAccessToken);
+        assertThat(refreshToken).isEqualTo(responseRefreshToken);
     }
 
     @Test
@@ -80,7 +69,6 @@ public class JwtUtilTest {
 
         //when
         String accessToken = jwtUtil.generateAccessToken(memberId, role);
-        accessToken = accessToken.substring(JwtUtil.BEARER_PREFIX.length());
 
         JwtClaimDTO jwtClaimDTO = jwtUtil.extractClaims(accessToken);
         Long jwtMemberId = jwtClaimDTO.getMemberId();
@@ -94,23 +82,24 @@ public class JwtUtilTest {
     }
 
     @Test
-    @DisplayName("성공적으로 로그인 및 토큰을 받아왔는지 확인합니다.")
+    @DisplayName("회원가입 이후 로그인 요청을 했을 때, 성공적으로 로그인 및 토큰을 받아왔는지 확인합니다.")
     void successfulAuthentication_test() throws Exception {
+        //given
         memberController.join(new JoinDTO("testtest","12341234",null));
+
         LoginDTO loginDto = new LoginDTO();
         loginDto.setUsername("testtest");
         loginDto.setPassword("12341234");
+
         String requestBody = objectMapper.writeValueAsString(loginDto);
-        System.out.println("테스트 : " + requestBody);
 
+        //when
         ResultActions resultActions = mockMvc.perform(post("/api/login").content(requestBody).contentType(MediaType.APPLICATION_JSON));
-        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
-        String jwtToken = resultActions.andReturn().getResponse().getHeader("Authorization");
 
-        System.out.println("테스트 : " + responseBody);
-        System.out.println("테스트 : " + jwtToken);
-
-        resultActions.andExpect(status().isOk());
-        assertTrue(jwtToken.startsWith(JwtUtil.BEARER_PREFIX));
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("AccessToken"))
+                .andExpect(cookie().exists("RefreshToken"));
     }
 }

--- a/backend/src/test/java/com/daily/daily/integration/auth/jwt/JwtUtilTest.java
+++ b/backend/src/test/java/com/daily/daily/integration/auth/jwt/JwtUtilTest.java
@@ -49,7 +49,7 @@ public class JwtUtilTest {
         MockHttpServletResponse mockResponse = new MockHttpServletResponse();
 
         String accessToken = jwtUtil.generateAccessToken(3L, MemberRole.ROLE_MEMBER);
-        String refreshToken = jwtUtil.createRefreshToken();
+        String refreshToken = jwtUtil.generateRefreshToken(3L);
 
         jwtUtil.setTokensInCookie(mockResponse, accessToken, refreshToken);
 


### PR DESCRIPTION
## 연관 이슈
close: #124 
## 작업 내용
- 로그인 성공시 토큰을 쿠키로 전달하도록 변경하였습니다. 
  (이유 및 자세한 내용은 Discord의 소셜로그인 쓰레드를 참고해주세요)
- 이전에는 로그인 성공시 토큰을 헤더로 줬었어서, 토큰을 헤더에 넣어주는 메서드들을 제거했습니다.
- JwtUtil클래스 리팩토링도 조금 했습니다.

## 의논할 거리
## Merge 전에 해야할 작업
## 기타
ㅎㅇㅌ